### PR TITLE
Cap tbx->scroll to 0 so that the cursor does not jump to the end of t…

### DIFF
--- a/src/sdlui_usage.cpp
+++ b/src/sdlui_usage.cpp
@@ -848,6 +848,10 @@ bool SDLUI_TextBox(SDLUI_Control_TextBox *tbx)
 			{
     				tbx->cursor_pos = tbx->text.length;
     				tbx->scroll = tbx->text.length - tbx->max_chars;
+    				if(tbx->scroll < 0)
+    				{
+                                         tbx->scroll = 0;
+    				}
 
         			SDL_SetRenderTarget(SDLUI_Core.renderer, tbx->tex_text);
         			SDL_Rect r = {0, 0, tbx->w, tbx->h};


### PR DESCRIPTION
…he text box even if the text box is empty or does not have enough text for it scroll.